### PR TITLE
Add integration testing for new param

### DIFF
--- a/awx_collection/tests/integration/targets/params/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/params/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: Perform an action with a different hostname via aap_hostname
+  inventory:
+    name: "Demo Inventory"
+    organization: Default
+    aap_hostname: https://foohostbar.invalid
+  ignore_errors: true
+  register: result
+
+- assert:
+    that:
+      - "'foohostbar' in result.msg"


### PR DESCRIPTION
##### SUMMARY
Tested locally as:

```
$ ansible-playbook -i localhost, awx_collection/tools/integration_testing.yml -e test=params

PLAY [localhost] *******************************************************************************************************************

TASK [DEBUG - make sure variables are what we expect] ******************************************************************************
ok: [localhost] => {
    "msg": "Running tests at location:\n    /home/alancoding/repos/awx/awx_collection/tools/../tests/integration/targets/\nRunning tests folders:\n    ['params']\n"
}

TASK [Include test targets] ********************************************************************************************************
included: /home/alancoding/repos/awx/awx_collection/tests/integration/targets/params/tasks/main.yml for localhost => (item=params)

TASK [Perform an action with a different hostname via aap_hostname] ****************************************************************
[WARNING]: Platform linux on host localhost is using the discovered Python interpreter at
/home/alancoding/venvs/ansible217/bin/python3.12, but future installation of another Python interpreter could change the meaning of
that path. See https://docs.ansible.com/ansible-core/2.17/reference_appendices/interpreter_discovery.html for more information.
fatal: [localhost]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/home/alancoding/venvs/ansible217/bin/python3.12"}, "changed": false, "msg": "Unable to resolve controller_host ([Errno -2] Name or service not known): foohostbar.invalid"}
...ignoring

TASK [assert] **********************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY RECAP *************************************************************************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
```

This is expanding the scope of the upstream integration tests a little bit, but I think Pablo can confirm, our options are limited these days.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection
